### PR TITLE
Move citation field to right-hand sidebar for all content types

### DIFF
--- a/modules/mukurtu_collection/config/install/core.entity_view_display.node.collection.full.yml
+++ b/modules/mukurtu_collection/config/install/core.entity_view_display.node.collection.full.yml
@@ -53,6 +53,7 @@ third_party_settings:
         - group_sidebar_mukurtu_fields
         - group_additional_metadata
         - group_rights
+        - group_citation
       label: Metadata
       parent_name: ''
       region: content
@@ -104,6 +105,26 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: sidebar-section
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_citation:
+      children:
+        - field_citation
+      label: Citation
+      parent_name: group_metadata
+      region: content
+      weight: 9
+      format_type: html_element
+      format_settings:
+        classes: sidebar-citation
         show_empty_fields: false
         id: ''
         label_as_html: false
@@ -336,6 +357,13 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  field_citation:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
+    region: content
   flag_export_content:
     settings: {  }
     third_party_settings: {  }
@@ -344,7 +372,6 @@ content:
 hidden:
   draft: true
   field_child_collections: true
-  field_citation: true
   field_collection_type: true
   field_content_type: true
   field_in_collection: true

--- a/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.dictionary_word.full.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.dictionary_word.full.yml
@@ -28,6 +28,7 @@ third_party_settings:
         - field_in_word_list
         - field_local_contexts_projects
         - field_local_contexts_labels_and_notices
+        - group_citation
         - flag_export_content
       label: Metadata
       parent_name: ''
@@ -124,7 +125,6 @@ third_party_settings:
         - field_coverage
         - field_location
         - field_coverage_description
-        - field_citation
         - field_related_content
       label: 'Additional Information'
       parent_name: group_primary_fields
@@ -140,6 +140,26 @@ third_party_settings:
         show_label: true
         label_element: h2
         label_element_classes: dictionary-word-subheading
+        attributes: ''
+        effect: none
+        speed: fast
+    group_citation:
+      children:
+        - field_citation
+      label: Citation
+      parent_name: group_metadata
+      region: content
+      weight: 40
+      format_type: html_element
+      format_settings:
+        classes: sidebar-citation
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
         attributes: ''
         effect: none
         speed: fast

--- a/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.full.yml
+++ b/modules/mukurtu_dictionary/config/install/core.entity_view_display.node.word_list.full.yml
@@ -227,6 +227,13 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  field_citation:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 13
+    region: content
   flag_export_content:
     settings: {  }
     third_party_settings: {  }
@@ -236,7 +243,6 @@ hidden:
   comment: true
   draft: true
   field_all_related_content: true
-  field_citation: true
   field_communities: true
   field_cultural_protocols: true
   field_in_collection: true

--- a/modules/mukurtu_digital_heritage/config/install/core.entity_view_display.node.digital_heritage.full.yml
+++ b/modules/mukurtu_digital_heritage/config/install/core.entity_view_display.node.digital_heritage.full.yml
@@ -30,6 +30,7 @@ third_party_settings:
         - group_sidebar_mukurtu_fields
         - group_additional_metadata
         - group_rights
+        - group_citation
         - flag_export_content
       label: Metadata
       parent_name: ''
@@ -59,7 +60,6 @@ third_party_settings:
         - field_coverage_description
         - field_transcription
         - field_all_related_content
-        - field_citation
         - comment
       label: 'Primary Fields'
       parent_name: ''
@@ -147,6 +147,26 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: sidebar-section
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_citation:
+      children:
+        - field_citation
+      label: Citation
+      parent_name: group_metadata
+      region: content
+      weight: 40
+      format_type: html_element
+      format_settings:
+        classes: sidebar-citation
         show_empty_fields: false
         id: ''
         label_as_html: false

--- a/modules/mukurtu_person/config/install/core.entity_view_display.node.person.full.yml
+++ b/modules/mukurtu_person/config/install/core.entity_view_display.node.person.full.yml
@@ -56,6 +56,7 @@ third_party_settings:
         - field_other_names
         - field_local_contexts_projects
         - field_local_contexts_labels_and_notices
+        - group_citation
         - flag_export_content
       label: Metadata
       parent_name: ''
@@ -64,6 +65,26 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_citation:
+      children:
+        - field_citation
+      label: Citation
+      parent_name: group_metadata
+      region: content
+      weight: 17
+      format_type: html_element
+      format_settings:
+        classes: sidebar-citation
         show_empty_fields: false
         id: ''
         label_as_html: false
@@ -280,6 +301,13 @@ content:
     third_party_settings: {  }
     weight: 10
     region: content
+  field_citation:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 18
+    region: content
   flag_export_content:
     settings: {  }
     third_party_settings: {  }
@@ -287,7 +315,6 @@ content:
     region: content
 hidden:
   draft: true
-  field_citation: true
   field_communities: true
   field_content_type: true
   field_cultural_protocols: true

--- a/themes/mukurtu_v4/css/style.css
+++ b/themes/mukurtu_v4/css/style.css
@@ -4882,13 +4882,21 @@ header {
   -webkit-border-before: 5px solid var(--mukurtu-view-row-divider-color);
           border-block-start: 5px solid var(--mukurtu-view-row-divider-color);
 }
-.full-node__citation .field--name-field-citation {
-  -webkit-padding-before: var(--v-space-2xs);
-          padding-block-start: var(--v-space-2xs);
-  -webkit-margin-before: var(--v-space-2xs);
-          margin-block-start: var(--v-space-2xs);
-  -webkit-border-before: 5px solid var(--mukurtu-view-row-divider-color);
-          border-block-start: 5px solid var(--mukurtu-view-row-divider-color);
+.sidebar-citation {
+  -webkit-padding-before: var(--v-space-4xxs);
+          padding-block-start: var(--v-space-4xxs);
+  -webkit-margin-before: var(--v-space-4xs);
+          margin-block-start: var(--v-space-4xs);
+  -webkit-border-before: 5px solid var(--brand-secondary);
+          border-block-start: 5px solid var(--brand-secondary);
+  padding: var(--v-space-4xxs);
+}
+.sidebar-citation .field--name-field-citation .field__label {
+  font-size: var(--font-size-s);
+  line-height: var(--line-height-xs);
+}
+.sidebar-citation .field--name-field-citation .field__item {
+  line-height: var(--line-height-s);
 }
 .full-node__comment {
   -webkit-margin-before: var(--v-space-xs);

--- a/themes/mukurtu_v4/templates/content/node--collection--full.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--collection--full.html.twig
@@ -123,6 +123,7 @@
             </div>
             {{ content.group_metadata.group_additional_metadata }}
             {{ content.group_metadata.group_rights }}
+            {{ content.group_metadata.group_citation }}
             {% if root_collection_has_children %}
               <div class="sidebar-section collection__menu">
                 <h2 class="collection__menu-title">{{ 'In this Collection'|t }}</h2>

--- a/themes/mukurtu_v4/templates/content/node--dictionary-word--full.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--dictionary-word--full.html.twig
@@ -104,7 +104,6 @@
             {{ content.group_primary_fields.group_additional_fields.field_coverage }}
             {{ content.group_primary_fields.group_additional_fields.field_location }}
             {{ content.group_primary_fields.group_additional_fields.field_coverage_description }}
-            {{ content.group_primary_fields.group_additional_fields.field_citation }}
 
           </div>
           {% elseif carousels == false  %}

--- a/themes/mukurtu_v4/templates/content/node--digital-heritage--full.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--digital-heritage--full.html.twig
@@ -104,15 +104,11 @@
             {{ content.group_primary_fields.field_media_assets }}
           {% endif %}
 
-          {{ content.group_primary_fields|without('field_all_related_content', 'field_media_assets', 'field_citation', 'comment') }}
+          {{ content.group_primary_fields|without('field_all_related_content', 'field_media_assets', 'comment') }}
         </div>
 
         <div class="full-node__related-content">
           {{ content.group_primary_fields.field_all_related_content }}
-        </div>
-
-        <div class="full-node__citation">
-          {{ content.group_primary_fields.field_citation }}
         </div>
 
         <div class="full-node__comment">
@@ -130,6 +126,7 @@
             </div>
             {{ content.group_metadata.group_additional_metadata }}
             {{ content.group_metadata.group_rights }}
+            {{ content.group_metadata.group_citation }}
             {{ content.group_metadata.flag_export_content }}
           </aside>
         </div>

--- a/themes/mukurtu_v4/templates/content/node--word-list--full.html.twig
+++ b/themes/mukurtu_v4/templates/content/node--word-list--full.html.twig
@@ -118,6 +118,9 @@
               {{ content.local_contexts_project }}
               {{ content.local_contexts_label_and_notice }}
             </div>
+            <div class="sidebar-citation">
+              {{ content.field_citation }}
+            </div>
           </aside>
         {% endif %}
 


### PR DESCRIPTION
Create a dedicated group_citation field group in the sidebar for digital heritage, collection, person, and dictionary word view displays. Enable citation display for collection, person, and word list content types that previously had it hidden. Update Twig templates to render citation in the sidebar and add sidebar-citation CSS styling.

Closes #1353

